### PR TITLE
フィードバックのタスクのタイトル調整

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.627.0",
         "@aws-sdk/s3-request-presigner": "^3.627.0",
+        "@google/generative-ai": "^0.24.1",
         "@octokit/rest": "^22.0.0",
         "@polyrhythm-inc/nextjs-auth-client": "*",
         "@prisma/client": "^6.10.0",
@@ -1666,6 +1667,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.627.0",
     "@aws-sdk/s3-request-presigner": "^3.627.0",
+    "@google/generative-ai": "^0.24.1",
     "@octokit/rest": "^22.0.0",
     "@polyrhythm-inc/nextjs-auth-client": "*",
     "@prisma/client": "^6.10.0",


### PR DESCRIPTION
フィードバックAPIで、タスクAPIをコールしてタスクを作成しますが、そのときのタイトルは、

・[フィードバック] の代わりに[FB]としてください。
・[FB]のあとに続くのは画面名ではなく、コメントの要約としたいです。Gemini APIを使って要約をしてください。APIコールでエラーになったら、コメントの最初の50文字としてください。
