### PR TITLE
[FB] Herokuデプロイ失敗の修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
       run: |
         # アプリケーション変数を環境変数から取得（ハードコード回避）
         APP_NAME="${{ secrets.HEROKU_APP_NAME }}"
-        WEB_URL="https://${{ secrets.HEROKU_APP_NAME }}.herokuapp.com/"
+        WEB_URL="https://${{ secrets.HEROKU_APP_NAME }}.herokuapp.com/api/health"
         
         echo "Performing health check..."
         echo "App Name: $APP_NAME"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    // データベース接続チェック（必要に応じて追加）
+    // const db = await getDatabase();
+    // await db.ping();
+
+    return NextResponse.json({
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      service: 'feedback-suite',
+      version: process.env.npm_package_version || '1.0.0'
+    });
+  } catch (error) {
+    console.error('Health check failed:', error);
+    return NextResponse.json(
+      {
+        status: 'unhealthy',
+        error: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString()
+      },
+      { status: 503 }
+    );
+  }
+}


### PR DESCRIPTION
## 概要
GitHub ActionsでHerokuへのデプロイが失敗していた問題を修正しました。

## 問題
- ヘルスチェックで`/`（ルートパス）にアクセスしていたが、このパスは認証が必要なため404エラーが発生
- デプロイは成功するが、ヘルスチェックでエラーになるためデプロイ全体が失敗扱いになっていた

## 修正内容
1. `/api/health`エンドポイントを新規作成
   - 認証不要でアクセス可能
   - アプリケーションの状態をJSON形式で返す
2. GitHub Actionsのヘルスチェックを`/api/health`を使用するように変更

## テスト
- [ ] ローカルで`/api/health`エンドポイントが正常に動作することを確認
- [ ] GitHub Actionsでデプロイが成功することを確認

## 関連タスク
- タスクID: 320
- エラー発生時刻: 2025/8/10 21:45

🤖 Generated with Claude Code